### PR TITLE
bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nunjucks-hapi",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "A simple wrapper to use Nunjucks templates in Hapi",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I noticed that somebody submitted a pull request to fix the module name typo, but the updated code never got released so when somebody types `npm install nunjucks-hapi` they still get the old version.

This bumps the version in `package.json` to 1.0.2. After you merge this, just _pull down_ and from your project directory use `npm publish` to update the version on npm.
